### PR TITLE
fix: adding revalidation to Static Pages

### DIFF
--- a/src/pages/elements/[id].tsx
+++ b/src/pages/elements/[id].tsx
@@ -159,5 +159,5 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
 
   const { data } = await getElementById({ id: id as string })
 
-  return { props: { data } }
+  return { props: { data }, revalidate: 60 }
 }

--- a/src/pages/elements/update/[id].tsx
+++ b/src/pages/elements/update/[id].tsx
@@ -450,6 +450,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
   const element = await getElementById({ id: id as string })
 
   return {
-    props: { elementData: element.data }
+    props: { elementData: element.data },
+    revalidate: 60
   }
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -13,7 +13,8 @@ export const getStaticProps: GetStaticProps = async () => {
   }
 
   return {
-    props: { data }
+    props: { data },
+    revalidate: 60
   }
 }
 


### PR DESCRIPTION
- Adding revalidation to Static pages because after editing or adding something they didn't show the updates